### PR TITLE
mapbox webpack fix

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,3 +1,2 @@
-
 REACT_APP_MAPBOXGL_ACCESS_TOKEN=pk.eyJ1Ijoia2RlYnJhdXciLCJhIjoiY2p4ZnhyaTUzMDB1eTQxbnVwOG9jbHBwdSJ9.L5RCSfMVV7RYpq1a45E68g
 REACT_APP_API_URL=https://api.incidentradar.com

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,4 +1,1 @@
-REACT_APP_API_URL= http://127.0.0.1:8000
-
-
-wordt met 'npm run start' over de .env heen geplakt
+REACT_APP_API_URL=http://127.0.0.1:8000

--- a/frontend/src/components/Application.js
+++ b/frontend/src/components/Application.js
@@ -1,5 +1,5 @@
 import * as axios from 'axios';
-import mapboxgl from 'mapbox-gl';
+import mapboxgl from '!mapbox-gl'; // eslint-disable-line import/no-webpack-loader-syntax
 import React from 'react';
 
 import logo from '../assets/logo_regular.png';


### PR DESCRIPTION
Ik heb https://docs.mapbox.com/mapbox-gl-js/api/#transpiling-v2 gelezen en ben voor optie twee gegaan: De bundle is niet compatible met Webpack/babel, en ik weet niet wiens schuld dat precies is.

De tweede optie ihttps://docs.mapbox.com/mapbox-gl-js/api/#excluding-gl-js-explicitly-from-transpilation en de truuk is dus om de import te prefixen met een `!` (webpack ondersteund een hele uitgebreide syntax in het import pad, maar dat is voor een andere keer).

De linter klaagde hierover:

```
Failed to compile.

src\components\Application.js
  Line 2:1:  Unexpected '!' in '!mapbox-gl'. Do not use import syntax to configure webpack loaders  import/no-webpack-loader-syntax
```

En ik denk dat de linter een goed punt heeft, en daarom heb ik 'm specifiek voor deze ene regel uitgeschakeld met het commentaar `// eslint-disable-line import/no-webpack-loader-syntax`.

Verder heb ik wat cleanup gedaan, er stonden wat ongeldige karakters in je `.env*` files.

Succes!